### PR TITLE
Scan ble en mode passif 

### DIFF
--- a/resources/blead/blead.py
+++ b/resources/blead/blead.py
@@ -158,10 +158,11 @@ def listen():
 					globals.SCANNER.clear()
 					globals.IGNORE[:] = []
 					globals.LAST_CLEAR = int(time.time())
-				globals.SCANNER.start()
 				if globals.LEARN_MODE:
+                    globals.SCANNER.start((passive=False))
 					globals.SCANNER.process(3)
 				else:
+                    globals.SCANNER.start((passive=True))
 					globals.SCANNER.process(0.3)
 				globals.SCANNER.stop()
 				if globals.SCAN_ERRORS > 0:

--- a/resources/blead/devices/xiaomiht.py
+++ b/resources/blead/devices/xiaomiht.py
@@ -4,6 +4,7 @@ import time
 import logging
 import globals
 import struct
+import utils
 from multiconnect import Connector
 from notification import Notification
 
@@ -18,7 +19,7 @@ class XiaomiHT():
 		if data.lower().startswith("95fe"):
 			#broadcasted advertising data
 			return True
-			
+	
 	def parse(self,data,mac,name,manuf):
 		action={}
 		action['present'] = 1
@@ -30,7 +31,7 @@ class XiaomiHT():
 			val_data = data[32:40]			 
 			if val_type in ['04']:	 # type: temperature
 				t_data = val_data[2:4] + val_data[0:2]
-				temp = int(t_data,16)/10.0
+				temp = utils.signed_int(t_data)/10.0
 				logging.debug('XiaomiHT------ Advertising Data=> Temp' + str(temp))
 				action['temperature'] = temp
 			elif val_type in ['06']: # type: moisture
@@ -45,7 +46,7 @@ class XiaomiHT():
 				action['battery'] = batt
 			elif val_type in ['0d']: # type: temp&moist
 				 t_data = val_data[2:4] + val_data[0:2]
-				 temp = int(t_data,16)/10.0
+				 temp = utils.signed_int(t_data)/10.0
 				 h_data = val_data[6:8] + val_data[4:6]
 				 hum = int(h_data,16)/10.0
 				 logging.debug('XiaomiHT------ Advertising Data=> Temp: ' + str(temp) + ' Moist: ' + str(hum))

--- a/resources/blead/devices/xiaomiht.py
+++ b/resources/blead/devices/xiaomiht.py
@@ -14,9 +14,9 @@ class XiaomiHT():
 		self.ignoreRepeat = True
 
 	def isvalid(self,name,manuf='',data=''):
-		if name.lower() in ['mj_ht_v1']:
+		if name.lower() in ['mj_ht_v1','cleargrass temp & rh']:
 			return True
-		if data.lower().startswith("95fe"):
+		if data.lower().startswith("95fe"): #dirty temporary fix, device doesn't report it's name with passive scan 
 			#broadcasted advertising data
 			return True
 	

--- a/resources/blead/utils.py
+++ b/resources/blead/utils.py
@@ -65,3 +65,9 @@ def twos_complement(value, bits):
 	if (value & (1 << (bits - 1))) != 0:
 		value = value - (1 << bits)
 	return value
+
+def signed_int(h):
+	x = int(h, 16)
+	if x > 32767:
+		x -= 65534
+	return x


### PR DESCRIPTION
Le scan en passif attend que le device envoie spontanément des données advertising.
En actif une trame est envoyée à tout les devices qui y répondent, parfois avec des données complémentaires 

J'ai constaté une incidence notable positive sur la consommation de batterie de mes appareils dans ce mode.

Idéalement, il faudrait plus tard rendre ça paramétrable depuis la page de configuration du plugin.