### PR TITLE
Ajout nouveau hardware miscale2, de type MIBFS en plus du type MIBCS

### DIFF
--- a/resources/blead/devices/miscale2.py
+++ b/resources/blead/devices/miscale2.py
@@ -14,7 +14,7 @@ class MiScale2():
 		self.ignoreRepeat = False
 
 	def isvalid(self,name,manuf='',data='',mac=''):
-		if name[0:5] == 'MIBCS' or name.lower() == self.name:
+		if name[0:5] == 'MIBCS' or name[0:5] == 'MIBFS' or name.lower() == self.name:
 			return True
 
 	def parse(self,data,mac,name,manuf):


### PR DESCRIPTION
Bonjour Loic,

cette modification concerne le sujet suivant: https://community.jeedom.com/t/demande-de-prise-en-charge-blea/25770/6

Cela permet de reconnaitre un nouveau type de hardware pour la balance miscale2 !

Merci a toi et a l'equipe jeedom de bien vouloir integrer cette modification.
Benoit