### PR TITLE
If Loglevel is not specified, then DEBUG level should not be selected

### DIFF
--- a/resources/blead/blead.py
+++ b/resources/blead/blead.py
@@ -530,7 +530,7 @@ args = parser.parse_args()
 
 if args.device:
 	globals.device = args.device
-if args.loglevel:
+if args.loglevel and args.loglevel != "none":
 	globals.log_level = args.loglevel
 if args.pidfile:
 	globals.pidfile = args.pidfile


### PR DESCRIPTION
Added a test on "none" value to avoid usage of DEBUG log level instead of default.