### PR TITLE
Problème bouton ajouter une commande

### DIFF
--- a/desktop/js/blea.js
+++ b/desktop/js/blea.js
@@ -82,6 +82,11 @@
 	}
 });
 
+$("#bt_addVirtualInfo").on('click', function (event) {
+  addCmdToTable({type: 'info'});
+  modifyWithoutSave = true;
+});
+
  $('#bt_healthblea').on('click', function () {
     $('#md_modal').dialog({title: "{{Santé BLEA}}"});
     $('#md_modal').load('index.php?v=d&plugin=blea&modal=health').dialog('open');


### PR DESCRIPTION
Bonjour, 
J'ai constaté que le bouton "ajouter une commande" dans l'onglet commande de l'équipement ne fonctionne pas. J'ai donc cherché et modifié du code dans blea.js pour que cela fonctionne à nouveau.

Cordialement

Superbricolo