### PR TITLE
Remove annoying "socket_connect" warning in cron_execution log

### DIFF
--- a/core/class/blea.class.php
+++ b/core/class/blea.class.php
@@ -1247,7 +1247,7 @@ class blea_remote {
 		$port = $this->getConfiguration('remotePort');
 		$user = $this->getConfiguration('remoteUser');
 		$pass = $this->getConfiguration('remotePassword');
-		if (!$connection = ssh2_connect($ip, $port)) {
+		if (!$connection = @ssh2_connect($ip, $port)) {
 			log::add('blea', 'error', 'connexion SSH KO for ' . $this->remoteName);
 				return false;
 		} else {
@@ -1326,7 +1326,7 @@ class blea_remote {
 		$port = $this->getConfiguration('remotePort');
 		$user = $this->getConfiguration('remoteUser');
 		$pass = $this->getConfiguration('remotePassword');
-		if (!$connection = ssh2_connect($ip, $port)) {
+		if (!$connection = @ssh2_connect($ip, $port)) {
 			log::add('blea', 'error', 'connexion SSH KO for ' . $this->remoteName);
 				return false;
 		} else {

--- a/core/class/blea.class.php
+++ b/core/class/blea.class.php
@@ -368,7 +368,7 @@ class blea extends eqLogic {
 		$value = json_encode($value);
 		$socket = socket_create(AF_INET, SOCK_STREAM, 0);
 		if ($socket) {
-			if (socket_connect($socket, $ip, config::byKey('socketport', 'blea'))) {
+			if (@socket_connect($socket, $ip, config::byKey('socketport', 'blea'))) {
 				socket_write($socket, $value, strlen($value));
 				socket_close($socket);
 			}


### PR DESCRIPTION
Recurrent warning in cron_execution log file :
`PHP Warning:  socket_connect(): unable to connect [111]: Connection refused in /var/www/html/plugins/blea/core/class/blea.class.php on line 371`

Error is already handled in code, no need to raise this error higher.